### PR TITLE
Tsdk-183: Updated examples to use new changes from today

### DIFF
--- a/src/main/scala/co/topl/brambl/Credentials.scala
+++ b/src/main/scala/co/topl/brambl/Credentials.scala
@@ -56,7 +56,7 @@ object Credentials {
    * @param unprovenTx
    * @return
    */
-  def proveIoTx[T](unprovenTx: UnprovenIoTx[T]): Tetra.IoTransaction = {
+  def proveIoTx[T <: Signable](unprovenTx: UnprovenIoTransaction[T]): Tetra.IoTransaction = {
     val message = unprovenTx.getSignableBytes
 
     val unprovenInput = unprovenTx.inputs.head
@@ -66,7 +66,7 @@ object Credentials {
       case v2: UnprovenSpentOutputV2 => proveSpentOutputV2(v2, message)
     }
 
-    Tetra.IoTransaction(List(provenInput), unprovenTx.outputs, unprovenTx.schedule, unprovenTx.metadata)
+    Tetra.IoTransaction(List(provenInput), unprovenTx.outputs, unprovenTx.datum, unprovenTx.metadata)
   }
 
 }

--- a/src/main/scala/co/topl/brambl/Storage.scala
+++ b/src/main/scala/co/topl/brambl/Storage.scala
@@ -54,7 +54,7 @@ object Storage {
   /**
    * Get an already existing box by its ID
    * */
-  def getBoxById(id: Box.Id): Box = boxes.getOrElse(id, None)
+  def getBoxById(id: Box.Id): Box = boxes(id)
 
   /**
    * Get an already existing genus TXO by its box ID

--- a/src/main/scala/co/topl/brambl/TransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/TransactionBuilder.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl
 
-import co.topl.node.Models.Metadata
 import co.topl.node.Tetra
 import co.topl.node.Tetra.Predicate
 import co.topl.brambl.Models._
@@ -40,11 +39,11 @@ object TransactionBuilder {
    * In addition to the indices being used to generate the digest secret, the indices will be used to
    * store the created proposition
    * */
-  private def buildUnspentOutput(idx: Indices, value: Tetra.Box.Value, meta: Tetra.Datums.UnspentOutput): Tetra.IoTx.UnspentOutput = {
+  private def buildUnspentOutput(idx: Indices, value: Tetra.Box.Value, meta: Tetra.Datums.UnspentOutput): Tetra.IoTransaction.UnspentOutput = {
     val proposition = QuivrService.getDigestProposition(getDigest(idx)) // or could be done with preimage
     val predicate = Tetra.Predicate(List(proposition), 1)
 
-    Tetra.IoTx.UnspentOutput(predicate.image.generateAddress, value, meta)
+    Tetra.IoTransaction.UnspentOutput(predicate.image.generateAddress, value, meta)
   }
 
   /**
@@ -57,15 +56,19 @@ object TransactionBuilder {
                                   input: Indices,
                                   output: Indices,
                                   outputValue: Tetra.Box.Value,
-                                  inputMeta: Tetra.Datums.SpentOutput = Tetra.Datums.SpentOutput(None),
-                                  outputMeta: Tetra.Datums.UnspentOutput = Tetra.Datums.UnspentOutput(None),
-                                  schedule: Tetra.IoTx.Schedule = Tetra.IoTx.Schedule(0, 0, 0),
-                                  metadata: Metadata = None
-                                ): UnprovenIoTx[UnprovenSpentOutputV1]  = {
+                                  inputMeta: Tetra.Datums.SpentOutput = Tetra.Datums.SpentOutput(Array()),
+                                  outputMeta: Tetra.Datums.UnspentOutput = Tetra.Datums.UnspentOutput(Array()),
+                                  datum: Tetra.Datums.IoTx = Tetra.Datums.IoTx(
+                                    Tetra.IoTransaction.Schedule(0, 0, 0),
+                                    Tetra.Blob.Id(Array()),
+                                    Array()
+                                  ),
+                                  metadata: Option[Tetra.Blob] = None
+                                ): UnprovenIoTransaction[UnprovenSpentOutputV1]  = {
     val inputs = List(buildUnprovenSpentOutputV1(input, inputMeta))
     val outputs = List(buildUnspentOutput(output, outputValue, outputMeta))
 
-    UnprovenIoTx[UnprovenSpentOutputV1](inputs, outputs, schedule, metadata)
+    UnprovenIoTransaction[UnprovenSpentOutputV1](inputs, outputs, datum, metadata)
   }
 
   /**
@@ -77,15 +80,19 @@ object TransactionBuilder {
   def buildUnprovenIoTxV2(
                            input: Txo,
                            outputValue: Tetra.Box.Value,
-                           inputMeta: Tetra.Datums.SpentOutput = Tetra.Datums.SpentOutput(None),
-                           outputMeta: Tetra.Datums.UnspentOutput = Tetra.Datums.UnspentOutput(None),
-                           schedule: Tetra.IoTx.Schedule = Tetra.IoTx.Schedule(0, 0, 0),
-                           metadata: Metadata = None
-                         ): UnprovenIoTx[UnprovenSpentOutputV2]  = {
+                           inputMeta: Tetra.Datums.SpentOutput = Tetra.Datums.SpentOutput(Array()),
+                           outputMeta: Tetra.Datums.UnspentOutput = Tetra.Datums.UnspentOutput(Array()),
+                           datum: Tetra.Datums.IoTx = Tetra.Datums.IoTx(
+                             Tetra.IoTransaction.Schedule(0, 0, 0),
+                             Tetra.Blob.Id(Array()),
+                             Array()
+                           ),
+                           metadata: Option[Tetra.Blob] = None
+                         ): UnprovenIoTransaction[UnprovenSpentOutputV2]  = {
     val inputs = List(buildUnprovenSpentOutputV2(input, inputMeta))
     val outputs = List(buildUnspentOutput(getNextIndices, outputValue, outputMeta))
 
-    UnprovenIoTx[UnprovenSpentOutputV2](inputs, outputs, schedule, metadata)
+    UnprovenIoTransaction[UnprovenSpentOutputV2](inputs, outputs, datum, metadata)
   }
 
 }

--- a/src/main/scala/co/topl/brambl/user.worksheet.sc
+++ b/src/main/scala/co/topl/brambl/user.worksheet.sc
@@ -1,50 +1,18 @@
-import co.topl.quivr.Models.Primitive
-import co.topl.quivr.SignableBytes
-import co.topl.quivr.{Proof, Proposer, Proposition, Prover, Verifier}
-import co.topl.crypto.hash.blake2b256
-import co.topl.quivr.runtime.DynamicContext
 import co.topl.brambl.{Credentials, TransactionBuilder}
 import co.topl.brambl.Models._
 import co.topl.node.Tetra.Box
-import co.topl.common.{Digest, Preimage}
 import co.topl.genus.Models.Txo
 import co.topl.brambl.QuivrService
 import co.topl.brambl.Storage.getTxo
 
 // Examples of how *Brambl* Quivr and Credentials will be called by a user of the SDK
-
-/***
- * Examples directly using the quivr library API; Proposer, Prover, and Verifier
- */
-def quivrExample: Unit = {
-  type Trivial[T] = T
-  // An Opinionated Verification Context
-  val ctx: DynamicContext[Trivial, String] = ???
-
-  // Proposer: Create Digest Proposition
-  val preImage: Array[Byte] = "random_data".getBytes
-  val digest: Array[Byte] = blake2b256.hash(preImage).value
-  val preImageObj: Preimage = Preimage(preImage, Array(0: Byte))
-  val digestObj: Digest = Digest(digest)
-  val proposition: Proposition = Proposer.digestProposer[Trivial, (String, Digest)].propose(("temp", digestObj))
-
-  // Prover: Create Digest Proof
-  val message: SignableBytes = ???
-  // Not sure if I instantiated the proof as it was intended
-  val prover: Prover[Trivial, (Byte, Preimage)] = Prover.instances.proverInstance
-  val proof: Proof = prover.prove((Primitive.Digest.token, preImageObj), message)
-
-  // Verifier: Verify if a Proof satisfies a Proposition given a Context
-  // Verifier does not need to know what kind of Proposition or Proof it's verifying.
-  val verifier: Verifier[Trivial] = Verifier.instances.verifierInstance
-  val isVerified: Boolean = verifier.evaluate(proposition, proof, ctx)
-}
-
-
 // The following are examples for Transaction builder and Credentials.
+
+
 val value = Box.Values.Token(1) // Arbitrary data
 
-// indices version
+
+// v1: indices version
 
 // Arbitrary data
 val idx1 = Indices(0, 0, 1)
@@ -62,7 +30,7 @@ val t2V1 = Credentials.proveIoTx[UnprovenSpentOutputV1](unprovenT2V1)
 val isT2V1Verified = QuivrService.verifyIoTx(t2V1)
 
 
-// txo version
+// v2: txo version
 
 // Arbitrary data
 // A TXO should be retrieved from Genus, but for now will retrieve from storage by indices

--- a/src/main/scala/co/topl/node/Tetra.scala
+++ b/src/main/scala/co/topl/node/Tetra.scala
@@ -2,7 +2,7 @@ package co.topl.node
 
 import co.topl.quivr
 import co.topl.quivr.SignableBytes
-import co.topl.quivr.runtime.{Datum, IncludesHeight, IncludesTick}
+import co.topl.quivr.runtime.{Datum, IncludesHeight}
 
 object Tetra {
 


### PR DESCRIPTION
# Summary of Changes

### Simple Brambl examples for: 
- creating an unproven transaction. Two versions depending on what information the user will have available (indices or Genus Txo) and whether we need to have Predicate.Known in an unproven input. For a loose visualization of the 2 versions, you can check out the [diagrams in this slack message](https://toplprotocol.slack.com/archives/C01TBT00MTJ/p1668814123819959).
- Proving an unproven transaction (Credentials). Two versions depending on if Predicate.Known is available in the unproven input
- Verifying a transaction (if the attestations are satisfied). **Note:** The relevant function (QuivrService.verify) is the only one that does not compile since quivr.api.Verifier is in flux and verifierInstance is commented out


The entry point to the examples is user.worksheet.sc. Each example is duplicated to show subsequent transfers; for example, in the indices version, transfer from indices1 to indices2, then from indices2 to indices3.

Note: I used implicit type conversions in brambl.Models as a workaround to modifying higher level files (specifically node.Tetra)