### PR TITLE
Tsdk-193 quickfix

### DIFF
--- a/src/main/scala/co/topl/quivr/api/Verifier.scala
+++ b/src/main/scala/co/topl/quivr/api/Verifier.scala
@@ -46,6 +46,16 @@ object Verifier {
     )
   } yield res
 
+  /**
+   * Collect the result of verification. Does the proof satisfy the proposition.
+   * Both msgResult and evalResult need to indicate success
+   *
+   * @param proposition The proposition that the proof was verified against
+   * @param proof The proof that was verified
+   * @param msgResult Result of message validation. Success is denoted by Right(true)
+   * @param evalResult Result of proposition and proof evaluation. Success is denoted by Right(_)
+   * @return The result of verification. If successful, Right(true). Else Left(QuivrRuntimeError)
+   */
   private def collectResult(proposition: Proposition, proof: Proof)(
     msgResult:                           Either[QuivrRuntimeError, Boolean],
     evalResult:                          Either[QuivrRuntimeError, _]

--- a/src/main/scala/co/topl/quivr/api/Verifier.scala
+++ b/src/main/scala/co/topl/quivr/api/Verifier.scala
@@ -117,7 +117,11 @@ object Verifier {
     ): F[Either[QuivrRuntimeError, Boolean]] = for {
       msgResult   <- Verifier.evaluateBlake2b256Bind(Models.Contextual.HeightRange.token, proof, context)
       chainHeight <- context.heightOf(proposition.chain)
-      evalResult = chainHeight.map(h => proposition.min <= h && h <= proposition.max)
+      evalResult = chainHeight.map(h =>
+        if(proposition.min <= h && h <= proposition.max)
+          Right(true)
+        else Left(EvaluationAuthorizationFailed(proposition, proof))
+      )
       res = collectResult(proposition, proof)(msgResult, evalResult)
     } yield res
 
@@ -127,7 +131,11 @@ object Verifier {
       context:     DynamicContext[F, String]
     ): F[Either[QuivrRuntimeError, Boolean]] = for {
       msgResult  <- Verifier.evaluateBlake2b256Bind(Models.Contextual.TickRange.token, proof, context)
-      evalResult <- context.currentTick.map(t => Right(proposition.min <= t && t <= proposition.max))
+      evalResult <- context.currentTick.map(t =>
+        if(proposition.min <= t && t <= proposition.max)
+          Right(true)
+        else Left(EvaluationAuthorizationFailed(proposition, proof))
+      )
       res = collectResult(proposition, proof)(msgResult, evalResult)
     } yield res
 

--- a/src/main/scala/co/topl/quivr/runtime/DynamicContext.scala
+++ b/src/main/scala/co/topl/quivr/runtime/DynamicContext.scala
@@ -15,7 +15,7 @@ import co.topl.quivr.runtime.QuivrRuntimeErrors.{ContextError, ValidationError}
  * @tparam K the key type that will be used to lookup values in the generic interface maps
  */
 trait DynamicContext[F[_], K] {
-  val datums: Map[K, Datum[_]]
+  val datums: K => Option[Datum[_]]
 
   val interfaces: Map[K, ParsableDataInterface]
   val signingRoutines: Map[K, SignatureVerifier[F]]
@@ -28,7 +28,7 @@ trait DynamicContext[F[_], K] {
   def heightOf(label: K)(implicit monad: Monad[F]): F[Either[QuivrRuntimeError, Long]] =
     EitherT
       .fromEither[F](
-        datums.get(label) match {
+        datums(label) match {
           case Some(v: IncludesHeight[_]) => Right(v.height)
           case _                          => Left(ContextError.FailedToFindDatum: QuivrRuntimeError)
         }


### PR DESCRIPTION
Minor changes to the quivr layer that came up during work on TSDK-193. Submitting these changes separately since it will affect @mundacho 's work.

Changes:
- Bug fix in heightVerifier and tickVerifier. Previously I was getting false positives; the verifier returned success even if the height/tick proposition was not satisfied. This is because collectResult assumes any Right(_) result is a success. To fix, instead of returning Right(false) when height/tick is not satisfied, return Left(error).
- Minor change to DynamicContext. Based on discussion end of last week; instead of Datums being a map, it will be a function that returns a Datum.