### PR TITLE
TSDK-219 Updated Errors Related to prove

### DIFF
--- a/src/main/scala/co/topl/brambl/wallet/CredentiallerError.scala
+++ b/src/main/scala/co/topl/brambl/wallet/CredentiallerError.scala
@@ -1,14 +1,13 @@
 package co.topl.brambl.wallet
 
-import co.topl.node.KnownIdentifier
-import co.topl.node.transaction.authorization
+import co.topl.node.transaction.{Attestation, authorization}
 
 sealed abstract class CredentiallerError
 
 object CredentiallerErrors {
 
   abstract class ProverError extends CredentiallerError
-  case class KnownIdentifierUnknown(knownIdentifier: KnownIdentifier) extends ProverError
+  case class AttestationMalformed(attestation: Attestation) extends ProverError
   case class ValidationError(error: authorization.ValidationError) extends CredentiallerError
 
 }


### PR DESCRIPTION
Updated Credentialler proveInput and getProof such that:

1) When proving a transaction with an invalid attestation (challenges and responses have different length), a AttestationMalformed error is returned. The length of challenges and responses must match or invoking `prove` will alter the signable bytes
2) When proving a transaction with an input that references a KnownIdentifier that is unknown to the wallet do not return an error. It is valid for a transaction to reference a box that does not yet exist. Instead, any proofs that require related information (signature and digest requires indices and secrets) will result to None.


The 2 affected functions are not publicly exposed but are updated here as a companion to the [changes in the draft specification ](https://github.com/Topl/sdk-spec/pull/25)