### PR TITLE
TSDK-221 Refactor Part 1

### DIFF
--- a/src/main/scala/co/topl/brambl/Context.scala
+++ b/src/main/scala/co/topl/brambl/Context.scala
@@ -4,7 +4,7 @@ import co.topl.brambl.digests.{Blake2b256Digest, Hash}
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.signatures.{Curve25519Signature, Signing}
-import co.topl.node.typeclasses.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.typeclasses.ContainsSignable.instances.ioTransactionSignable
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.quivr.algebras.{DigestVerifier, SignatureVerifier}
 import quivr.models.SignableBytes

--- a/src/main/scala/co/topl/brambl/authorization/ValidationAlgebra.scala
+++ b/src/main/scala/co/topl/brambl/authorization/ValidationAlgebra.scala
@@ -1,9 +1,9 @@
-package co.topl.node.transaction.authorization
+package co.topl.brambl.authorization
 
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.quivr.runtime.DynamicContext
 import co.topl.common.ContextualValidation
+import co.topl.quivr.runtime.DynamicContext
 
 trait ValidationAlgebra[F[_]]
     extends ContextualValidation[F, ValidationError, IoTransaction, DynamicContext[F, String, Datum]]

--- a/src/main/scala/co/topl/brambl/authorization/ValidationError.scala
+++ b/src/main/scala/co/topl/brambl/authorization/ValidationError.scala
@@ -1,4 +1,4 @@
-package co.topl.node.transaction.authorization
+package co.topl.brambl.authorization
 
 import quivr.models.{Proof, Proposition}
 

--- a/src/main/scala/co/topl/brambl/authorization/ValidationInterpreter.scala
+++ b/src/main/scala/co/topl/brambl/authorization/ValidationInterpreter.scala
@@ -1,15 +1,12 @@
-package co.topl.node.transaction.authorization
+package co.topl.brambl.authorization
 
 import cats.Monad
 import cats.implicits._
-import co.topl.brambl.models.Datum
-import co.topl.brambl.models.Identifier
-import co.topl.brambl.models.transaction.Attestation
-import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.models.{Datum, Identifier}
+import co.topl.brambl.models.transaction.{Attestation, IoTransaction}
 import co.topl.quivr.api.Verifier
 import co.topl.quivr.runtime.DynamicContext
-import quivr.models.Proof
-import quivr.models.Proposition
+import quivr.models.{Proof, Proposition}
 
 /**
  * Validates that each Input within a Transaction is properly "authorized".  "Authorized" simply means "does the given

--- a/src/main/scala/co/topl/brambl/typeclasses/ContainsEvidence.scala
+++ b/src/main/scala/co/topl/brambl/typeclasses/ContainsEvidence.scala
@@ -1,11 +1,11 @@
-package co.topl.node.typeclasses
+package co.topl.brambl.typeclasses
 
 import cats.implicits._
 import co.topl.brambl.models.Evidence
 import co.topl.crypto.accumulators.LeafData
 import co.topl.crypto.accumulators.merkle.MerkleTree
 import co.topl.crypto.hash.digest.{Digest32, Digest64}
-import co.topl.crypto.hash.{blake2b256, blake2b512, Blake2b}
+import co.topl.crypto.hash.{Blake2b, blake2b256, blake2b512}
 import co.topl.crypto.implicits.{blake2b256Hash, blake2b512Hash, digestDigest32, digestDigest64}
 import com.google.protobuf.ByteString
 import quivr.models.Digest

--- a/src/main/scala/co/topl/brambl/typeclasses/ContainsSignable.scala
+++ b/src/main/scala/co/topl/brambl/typeclasses/ContainsSignable.scala
@@ -1,12 +1,9 @@
-package co.topl.node.typeclasses
+package co.topl.brambl.typeclasses
 
 import co.topl.brambl.Tags
-import co.topl.brambl.models.Datum
-import co.topl.brambl.models.box.Box
-import co.topl.brambl.models.transaction._
 import co.topl.brambl.models._
-import co.topl.brambl.models.box.Lock
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.{Box, Lock, Value}
+import co.topl.brambl.models.transaction._
 import co.topl.quivr.Tokens
 import com.google.protobuf.ByteString
 import quivr.models._

--- a/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
+++ b/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
@@ -2,14 +2,14 @@ package co.topl.brambl.wallet
 
 import cats.implicits._
 import co.topl.brambl.Models.Indices
+import co.topl.brambl.authorization.ValidationInterpreter
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.Attestation
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.transaction.SpentTransactionOutput
 import co.topl.brambl.wallet.CredentiallerErrors.{ProverError, ValidationError}
 import co.topl.brambl.{Context, QuivrService}
-import co.topl.node.transaction.authorization.ValidationInterpreter
-import co.topl.node.typeclasses.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.typeclasses.ContainsSignable.instances.ioTransactionSignable
 import co.topl.quivr.api.Verifier
 import quivr.models.Proof
 import quivr.models.Proposition

--- a/src/main/scala/co/topl/brambl/wallet/Credentialler.test.sc
+++ b/src/main/scala/co/topl/brambl/wallet/Credentialler.test.sc
@@ -8,7 +8,7 @@ import co.topl.brambl.wallet.{Credentialler, MockStorage}
 import co.topl.node.box.Locks
 import co.topl.node.{Address, Events, Identifiers}
 import co.topl.node.transaction.{Datums, IoTransaction}
-import co.topl.node.typeclasses.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.typeclasses.ContainsSignable.instances.ioTransactionSignable
 
 // A "Valid" context is one where the hardcoded Height and Tick propositions will be satisfied (value of 5).
 def getValidContext(tx: IoTransaction): Context = Context(tx, 5,

--- a/src/main/scala/co/topl/brambl/wallet/CredentiallerError.scala
+++ b/src/main/scala/co/topl/brambl/wallet/CredentiallerError.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.wallet
 
 import co.topl.brambl.models.transaction.Attestation
-import co.topl.node.transaction.authorization
+import co.topl.brambl.authorization.{ValidationError => AuthorizationValidationError}
 
 sealed abstract class CredentiallerError
 
@@ -9,6 +9,6 @@ object CredentiallerErrors {
 
   abstract class ProverError extends CredentiallerError
   case class AttestationMalformed(attestation: Attestation) extends ProverError
-  case class ValidationError(error: authorization.ValidationError) extends CredentiallerError
+  case class ValidationError(error: AuthorizationValidationError) extends CredentiallerError
 
 }

--- a/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
+++ b/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
@@ -15,11 +15,11 @@ import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.transaction.Schedule
-import co.topl.node.typeclasses.ContainsEvidence
+import co.topl.brambl.typeclasses.ContainsEvidence
 import com.google.protobuf.ByteString
 import quivr.models.Preimage
 import quivr.models.VerificationKey
-import co.topl.node.typeclasses.ContainsSignable.instances._
+import co.topl.brambl.typeclasses.ContainsSignable.instances._
 import ContainsEvidence._
 import quivr.models.Int128
 

--- a/src/main/scala/co/topl/genus/OutputState.scala
+++ b/src/main/scala/co/topl/genus/OutputState.scala
@@ -1,8 +1,0 @@
-package co.topl.genus
-
-sealed abstract class OutputState
-
-object OutputStates {
-  case object Spent extends OutputState
-  case object Unspent extends OutputState
-}

--- a/src/main/scala/co/topl/genus/TransactionOutput.scala
+++ b/src/main/scala/co/topl/genus/TransactionOutput.scala
@@ -1,8 +1,0 @@
-package co.topl.genus
-
-//case class TransactionOutput(
-//  id:       Box.Id,
-//  boxValue: Box.Value,
-//  address:  Address,
-//  state:    OutputState = OutputStates.Unspent
-//)

--- a/src/main/scala/co/topl/node/package.scala
+++ b/src/main/scala/co/topl/node/package.scala
@@ -1,6 +1,0 @@
-package co.topl
-
-package object node {
-  type SmallData = Array[Byte] // small, up to 64 bytes
-  type Root = Array[Byte] // fixed size 32 or 64 bytes as a root from an accumulator
-}


### PR DESCRIPTION
Content and implementation logic of validation is not changed in this PR. 

**Changes:**

- Removed `genus` package since it is currently not being used in the brambl examples.
- Moved `authorization` and `typeclasses` packages from `node` to `brambl`
- Removed `node/package.scala` since it was no longer being used. 

These changes eradicates Genus and Node layers from quivr4s playground examples. The dependencies remaining are `common > quivr > brambl`
