### PR TITLE
TSDK-221 Replaced Option with Id

### DIFF
--- a/src/main/scala/co/topl/brambl/Context.scala
+++ b/src/main/scala/co/topl/brambl/Context.scala
@@ -1,12 +1,12 @@
 package co.topl.brambl
 
+import cats.Id
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.routines.digests.validators.Blake2b256DigestInterpreter
-import co.topl.brambl.routines.digests.{Blake2b256Digest, Hash}
 import co.topl.brambl.routines.signatures.validators.Curve25519SignatureInterpreter
-import co.topl.brambl.routines.signatures.{Curve25519Signature, Signing}
 import co.topl.brambl.typeclasses.ContainsSignable.instances.ioTransactionSignable
+import co.topl.common.ParsableDataInterface
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.quivr.algebras.{DigestVerifier, SignatureVerifier}
 import quivr.models.SignableBytes
@@ -14,23 +14,24 @@ import quivr.models.SignableBytes
 // A Verification Context opinionated to the Topl context.
 // signableBytes, currentTick and the datums are dynamic
 case class Context(tx: IoTransaction, curTick: Long, heightDatums: String => Option[Datum])
-    extends DynamicContext[Option, String, Datum] {
+    extends DynamicContext[Id, String, Datum] {
 
-  override val hashingRoutines: Map[String, DigestVerifier[Option]] =
+  override val hashingRoutines: Map[String, DigestVerifier[Id]] =
     Map("blake2b256" -> Blake2b256DigestInterpreter)
 
-  override val signingRoutines: Map[String, SignatureVerifier[Option]] =
+  override val signingRoutines: Map[String, SignatureVerifier[Id]] =
     Map("curve25519" -> Curve25519SignatureInterpreter)
-  override val interfaces = Map() // Arbitrary
 
-  override def signableBytes: Option[SignableBytes] = Option(ioTransactionSignable.signableBytes(tx))
+  override val interfaces: Map[String, ParsableDataInterface] = Map() // Arbitrary
 
-  override def currentTick: Option[Long] = Some(curTick)
+  override def signableBytes: Id[SignableBytes] = ioTransactionSignable.signableBytes(tx)
+
+  override def currentTick: Id[Long] = curTick
 
   // Needed for height
   override val datums: String => Option[Datum] = heightDatums
 
-  def heightOf(label: String): Option[Option[Long]] = heightDatums(label).map(_.value match {
+  def heightOf(label: String): Id[Option[Long]] = heightDatums(label).flatMap(_.value match {
     case Datum.Value.Header(h) => h.event.map(_.height)
     case _                     => None
   })

--- a/src/main/scala/co/topl/brambl/QuivrService.scala
+++ b/src/main/scala/co/topl/brambl/QuivrService.scala
@@ -1,5 +1,6 @@
 package co.topl.brambl
 
+import cats.Id
 import co.topl.brambl.Models.SigningKey
 import co.topl.brambl.routines.digests.Hash
 import co.topl.brambl.routines.signatures.Signing
@@ -10,35 +11,35 @@ import co.topl.quivr.api.{Proposer, Prover}
 
 object QuivrService {
 
-  def lockedProposition: Option[Proposition] =
-    Proposer.LockedProposer[Option].propose(None)
+  def lockedProposition: Id[Proposition] =
+    Proposer.LockedProposer[Id].propose(None)
 
-  def lockedProof(msg: SignableBytes): Option[Proof] =
-    Prover.lockedProver[Option].prove((), msg)
+  def lockedProof(msg: SignableBytes): Id[Proof] =
+    Prover.lockedProver[Id].prove((), msg)
 
-  def digestProposition(preimage: Preimage, routine: Hash): Option[Proposition] =
-    Proposer.digestProposer[Option].propose((routine.routine, routine.hash(preimage)))
+  def digestProposition(preimage: Preimage, routine: Hash): Id[Proposition] =
+    Proposer.digestProposer[Id].propose((routine.routine, routine.hash(preimage)))
 
-  def digestProof(msg: SignableBytes, preimage: Preimage): Option[Proof] =
-    Prover.digestProver[Option].prove(preimage, msg)
+  def digestProof(msg: SignableBytes, preimage: Preimage): Id[Proof] =
+    Prover.digestProver[Id].prove(preimage, msg)
 
   // Hardcoding "curve25519"
-  def signatureProposition(vk: VerificationKey, routine: Signing): Option[Proposition] =
-    Proposer.signatureProposer[Option].propose((routine.routine, vk))
+  def signatureProposition(vk: VerificationKey, routine: Signing): Id[Proposition] =
+    Proposer.signatureProposer[Id].propose((routine.routine, vk))
 
-  def signatureProof(msg: SignableBytes, sk: SigningKey, routine: Signing): Option[Proof] =
-    Prover.signatureProver[Option].prove(routine.sign(sk, msg), msg)
+  def signatureProof(msg: SignableBytes, sk: SigningKey, routine: Signing): Id[Proof] =
+    Prover.signatureProver[Id].prove(routine.sign(sk, msg), msg)
 
-  def heightProposition(min: Long, max: Long, chain: String = "header"): Option[Proposition] =
-    Proposer.heightProposer[Option].propose((chain, min, max))
+  def heightProposition(min: Long, max: Long, chain: String = "header"): Id[Proposition] =
+    Proposer.heightProposer[Id].propose((chain, min, max))
 
-  def heightProof(msg: SignableBytes): Option[Proof] =
-    Prover.heightProver[Option].prove((), msg)
+  def heightProof(msg: SignableBytes): Id[Proof] =
+    Prover.heightProver[Id].prove((), msg)
 
-  def tickProposition(min: Long, max: Long): Option[Proposition] =
-    Proposer.tickProposer[Option].propose((min, max))
+  def tickProposition(min: Long, max: Long): Id[Proposition] =
+    Proposer.tickProposer[Id].propose((min, max))
 
-  def tickProof(msg: SignableBytes): Option[Proof] =
-    Prover.tickProver[Option].prove((), msg)
+  def tickProof(msg: SignableBytes): Id[Proof] =
+    Prover.tickProver[Id].prove((), msg)
 
 }

--- a/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
+++ b/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
@@ -1,10 +1,8 @@
 package co.topl.brambl.routines.digests
 
 import co.topl.crypto.hash.blake2b256
-import co.topl.quivr.algebras.DigestVerifier
-import co.topl.quivr.runtime.{QuivrRuntimeError, QuivrRuntimeErrors}
 import com.google.protobuf.ByteString
-import quivr.models.{Digest, DigestVerification, Preimage}
+import quivr.models.{Digest, Preimage}
 
 object Blake2b256Digest extends Hash {
   override val routine: String = "blake2b256"

--- a/src/main/scala/co/topl/brambl/routines/digests/validators/Blake2b256DigestInterpreter.scala
+++ b/src/main/scala/co/topl/brambl/routines/digests/validators/Blake2b256DigestInterpreter.scala
@@ -1,20 +1,18 @@
 package co.topl.brambl.routines.digests.validators
 
+import cats.Id
 import co.topl.brambl.routines.Routine
 import co.topl.crypto.hash.blake2b256
 import co.topl.quivr.algebras.DigestVerifier
 import co.topl.quivr.runtime.{QuivrRuntimeError, QuivrRuntimeErrors}
-import com.google.protobuf.ByteString
-import quivr.models.{Digest, DigestVerification, Preimage}
+import quivr.models.DigestVerification
 
-object Blake2b256DigestInterpreter extends DigestVerifier[Option] with Routine {
+object Blake2b256DigestInterpreter extends DigestVerifier[Id] with Routine {
   override val routine: String = "blake2b256"
 
-  override def validate(v: DigestVerification): Option[Either[QuivrRuntimeError, DigestVerification]] = {
+  override def validate(v: DigestVerification): Id[Either[QuivrRuntimeError, DigestVerification]] = {
     val test = blake2b256.hash(v.preimage.get.input.toByteArray ++ v.preimage.get.salt.toByteArray).value
-    Some(
-      if (v.digest.get.value.digest32.get.value.toByteArray.sameElements(test)) Right(v)
-      else Left(QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable)
-    )
+    if (v.digest.get.value.digest32.get.value.toByteArray.sameElements(test)) Right(v)
+    else Left(QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable)
   }
 }

--- a/src/main/scala/co/topl/brambl/routines/signatures/validators/Curve25519SignatureInterpreter.scala
+++ b/src/main/scala/co/topl/brambl/routines/signatures/validators/Curve25519SignatureInterpreter.scala
@@ -1,23 +1,22 @@
 package co.topl.brambl.routines.signatures.validators
 
+import cats.Id
 import co.topl.brambl.routines.Routine
 import co.topl.crypto.{PublicKey, signatures}
 import co.topl.quivr.algebras.SignatureVerifier
 import co.topl.quivr.runtime.{QuivrRuntimeError, QuivrRuntimeErrors}
 import quivr.models.SignatureVerification
 
-object Curve25519SignatureInterpreter extends SignatureVerifier[Option] with Routine {
+object Curve25519SignatureInterpreter extends SignatureVerifier[Id] with Routine {
   override val routine: String = "curve25519"
 
-  override def validate(v: SignatureVerification): Option[Either[QuivrRuntimeError, SignatureVerification]] =
-    Some(
-      if (
-        signatures.Curve25519.verify(
-          signatures.Signature(v.signature.get.value.toByteArray),
-          v.message.get.value.toByteArray,
-          PublicKey(v.verificationKey.get.value.toByteArray)
-        )
-      ) Right(v)
-      else Left(QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable)
-    )
+  override def validate(v: SignatureVerification): Id[Either[QuivrRuntimeError, SignatureVerification]] =
+    if (
+      signatures.Curve25519.verify(
+        signatures.Signature(v.signature.get.value.toByteArray),
+        v.message.get.value.toByteArray,
+        PublicKey(v.verificationKey.get.value.toByteArray)
+      )
+    ) Right(v)
+    else Left(QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable)
 }

--- a/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
+++ b/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
@@ -115,24 +115,22 @@ object MockStorage extends Storage {
   // Hardcoding MockStorage to use Blake2b256Digest and Curve25519Signature
   private def buildPredicate(threshold: Int, idx: Indices): Lock.Predicate = Lock.Predicate(
     List(
-      QuivrService.lockedProposition.get,
+      QuivrService.lockedProposition,
       QuivrService
         .digestProposition(
           getPreimage(idx)
             .getOrElse(Preimage(ByteString.copyFromUtf8("unsolvable preimage"), ByteString.copyFromUtf8("salt"))),
           Blake2b256Digest
-        )
-        .get,
+        ),
       QuivrService
         .signatureProposition(
           getKeyPair(idx, Curve25519Signature)
             .getOrElse(KeyPair(SigningKey("fake sk".getBytes), VerificationKey(ByteString.copyFromUtf8("fake vk"))))
             .vk,
           Curve25519Signature
-        )
-        .get,
-      QuivrService.heightProposition(2, 8).get,
-      QuivrService.tickProposition(2, 8).get
+        ),
+      QuivrService.heightProposition(2, 8),
+      QuivrService.tickProposition(2, 8)
     ),
     threshold // N of 5 predicate
   )


### PR DESCRIPTION
[Per thread in a different PR](https://github.com/Topl/quivr4s/pull/9#discussion_r1063767223), it was recommended to use Cats.Id instead of Option to satisfy F[_] type. 

Changes:
- In all areas where Option was used for the sole purpose of satisfying F[_], replace with Id. 
- Updated any affected callers to align with the change.