### PR TITLE
TSDK-221 Move existing brambl models to PB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "co.topl" %% "crypto" % "1.10.2",
   "org.typelevel" %% "simulacrum" % "1.0.1",
   "org.scalameta" %% "munit" % "0.7.29" % Test,
-  "com.github.Topl" % "protobuf-specs" % "d58fd6f"
+  "com.github.Topl" % "protobuf-specs" % "jitpack-tag-1"
 )
 
 // For Scala 2.13+

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "co.topl" %% "crypto" % "1.10.2",
   "org.typelevel" %% "simulacrum" % "1.0.1",
   "org.scalameta" %% "munit" % "0.7.29" % Test,
-  "com.github.Topl" % "protobuf-specs" % "dc64de90"
+  "com.github.Topl" % "protobuf-specs" % "d58fd6f"
 )
 
 // For Scala 2.13+

--- a/src/main/scala/co/topl/brambl/Models.scala
+++ b/src/main/scala/co/topl/brambl/Models.scala
@@ -1,9 +1,0 @@
-package co.topl.brambl
-
-import quivr.models.VerificationKey
-
-object Models {
-  case class SigningKey(value: Array[Byte]) // To mirror VerificationKey
-  case class KeyPair(sk: SigningKey, vk: VerificationKey)
-  case class Indices(x: Int, y: Int, z: Int)
-}

--- a/src/main/scala/co/topl/brambl/QuivrService.scala
+++ b/src/main/scala/co/topl/brambl/QuivrService.scala
@@ -1,7 +1,6 @@
 package co.topl.brambl
 
 import cats.Id
-import co.topl.brambl.Models.SigningKey
 import co.topl.brambl.routines.digests.Hash
 import co.topl.brambl.routines.signatures.Signing
 import quivr.models._

--- a/src/main/scala/co/topl/brambl/routines/signatures/Curve25519Signature.scala
+++ b/src/main/scala/co/topl/brambl/routines/signatures/Curve25519Signature.scala
@@ -1,11 +1,9 @@
 package co.topl.brambl.routines.signatures
 
-import co.topl.brambl.Models.{KeyPair, SigningKey}
-import co.topl.crypto.{PrivateKey, PublicKey, signatures}
-import co.topl.quivr.algebras.SignatureVerifier
-import co.topl.quivr.runtime.{QuivrRuntimeError, QuivrRuntimeErrors}
+import cats.implicits.catsSyntaxOptionId
+import co.topl.crypto.{PrivateKey, signatures}
 import com.google.protobuf.ByteString
-import quivr.models.{SignableBytes, SignatureVerification, VerificationKey, Witness}
+import quivr.models.{KeyPair, SignableBytes, SigningKey, VerificationKey, Witness}
 
 object Curve25519Signature extends Signing {
   override val routine: String = "curve25519"
@@ -14,9 +12,12 @@ object Curve25519Signature extends Signing {
     val (sk, vk) = signatures.Curve25519.createKeyPair(seed)
     val skBytes = sk.value
     val vkBytes = vk.value
-    KeyPair(SigningKey(skBytes), VerificationKey(ByteString.copyFrom(vkBytes)))
+    KeyPair(
+      VerificationKey(ByteString.copyFrom(vkBytes)).some,
+      SigningKey(ByteString.copyFrom(skBytes)).some
+    )
   }
 
   override def sign(sk: SigningKey, msg: SignableBytes): Witness =
-    Witness(ByteString.copyFrom(signatures.Curve25519.sign(PrivateKey(sk.value), msg.value.toByteArray).value))
+    Witness(ByteString.copyFrom(signatures.Curve25519.sign(PrivateKey(sk.value.toByteArray), msg.value.toByteArray).value))
 }

--- a/src/main/scala/co/topl/brambl/routines/signatures/Signing.scala
+++ b/src/main/scala/co/topl/brambl/routines/signatures/Signing.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl.routines.signatures
 
-import co.topl.brambl.Models.{KeyPair, SigningKey}
 import co.topl.brambl.routines.Routine
 import quivr.models._
 

--- a/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
+++ b/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
@@ -2,7 +2,6 @@ package co.topl.brambl.wallet
 
 import cats.Id
 import cats.implicits._
-import co.topl.brambl.Models.Indices
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.Attestation
 import co.topl.brambl.models.transaction.IoTransaction
@@ -17,6 +16,7 @@ import co.topl.quivr.api.Verifier
 import quivr.models.Proof
 import quivr.models.Proposition
 import quivr.models.SignableBytes
+import co.topl.brambl.models.Indices
 
 case class Credentialler(store: Storage)(implicit ctx: Context) extends Credentials {
 
@@ -47,7 +47,8 @@ case class Credentialler(store: Storage)(implicit ctx: Context) extends Credenti
           .flatMap(r =>
             idx
               .flatMap(i => store.getKeyPair(i, r))
-              .map(keyPair => QuivrService.signatureProof(msg, keyPair.sk, r))
+              .flatMap(keyPair => keyPair.sk)
+              .map(sk => QuivrService.signatureProof(msg, sk, r))
           )
       case _: Proposition.Value.HeightRange => Some(QuivrService.heightProof(msg))
       case _: Proposition.Value.TickRange   => Some(QuivrService.tickProof(msg))

--- a/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
+++ b/src/main/scala/co/topl/brambl/wallet/MockStorage.scala
@@ -1,7 +1,6 @@
 package co.topl.brambl.wallet
 
 import cats.implicits._
-import co.topl.brambl.Models.{Indices, KeyPair, SigningKey}
 import co.topl.brambl.QuivrService
 import co.topl.brambl.models.Address
 import co.topl.brambl.models.Datum
@@ -13,10 +12,13 @@ import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.transaction.Schedule
+import co.topl.brambl.models.Indices
 import co.topl.brambl.typeclasses.ContainsEvidence
 import com.google.protobuf.ByteString
 import quivr.models.Preimage
 import quivr.models.VerificationKey
+import quivr.models.SigningKey
+import quivr.models.KeyPair
 import co.topl.brambl.typeclasses.ContainsSignable.instances._
 import ContainsEvidence._
 import co.topl.brambl.routines.digests.Blake2b256Digest
@@ -125,8 +127,8 @@ object MockStorage extends Storage {
       QuivrService
         .signatureProposition(
           getKeyPair(idx, Curve25519Signature)
-            .getOrElse(KeyPair(SigningKey("fake sk".getBytes), VerificationKey(ByteString.copyFromUtf8("fake vk"))))
-            .vk,
+            .getOrElse(KeyPair(VerificationKey(ByteString.copyFromUtf8("fake vk")).some, SigningKey(ByteString.copyFromUtf8("fake sk")).some))
+            .vk.getOrElse(VerificationKey(ByteString.copyFromUtf8("backup vk"))),
           Curve25519Signature
         ),
       QuivrService.heightProposition(2, 8),

--- a/src/main/scala/co/topl/brambl/wallet/Storage.scala
+++ b/src/main/scala/co/topl/brambl/wallet/Storage.scala
@@ -1,11 +1,11 @@
 package co.topl.brambl.wallet
 
-import co.topl.brambl.Models.{Indices, KeyPair}
 import co.topl.brambl.models.Address
 import co.topl.brambl.models.KnownIdentifier
 import co.topl.brambl.models.box.Box
 import co.topl.brambl.routines.signatures.Signing
-import quivr.models.Preimage
+import quivr.models.{Preimage, KeyPair}
+import co.topl.brambl.models.Indices
 
 trait Storage {
   // Return the indices associated to a known identifier


### PR DESCRIPTION
This is a companion PR to [an update to the protobuf-specs](https://github.com/Topl/protobuf-specs/pull/22).

Changes:
- Removed brambl/models (contains 3 models)
- reference protobufs for the 3 models.
- Update the commit hash JitPack will use to consume PB.  After the companion PR is merged into protobuf-specs main, this hash will need to be updated prior to merging this PR