### PR TITLE
TSDK-221 Builders Part 2

### DIFF
--- a/src/main/scala/co/topl/brambl/builders/InputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/InputBuilder.scala
@@ -1,9 +1,8 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
+import co.topl.brambl.builders.Models.InputBuildRequest
 import co.topl.brambl.models.transaction.SpentTransactionOutput
-import co.topl.brambl.models.Datum.{SpentOutput => Datum}
 
 trait InputBuilder {
-  def constructUnprovenInput(idx: Indices, datum: Option[Datum]): Either[BuilderError, SpentTransactionOutput]
+  def constructUnprovenInput(data: InputBuildRequest): Either[BuilderError, SpentTransactionOutput]
 }

--- a/src/main/scala/co/topl/brambl/builders/MockInputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockInputBuilder.scala
@@ -1,0 +1,10 @@
+package co.topl.brambl.builders
+
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.Datum.{SpentOutput => Datum}
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+
+
+object MockInputBuilder extends InputBuilder {
+  override def constructUnprovenInput(idx: Indices, datum: Option[Datum]): Either[BuilderError, SpentTransactionOutput] = ???
+}

--- a/src/main/scala/co/topl/brambl/builders/MockInputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockInputBuilder.scala
@@ -1,10 +1,9 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
-import co.topl.brambl.models.Datum.{SpentOutput => Datum}
+import co.topl.brambl.builders.Models.InputBuildRequest
 import co.topl.brambl.models.transaction.SpentTransactionOutput
 
 
 object MockInputBuilder extends InputBuilder {
-  override def constructUnprovenInput(idx: Indices, datum: Option[Datum]): Either[BuilderError, SpentTransactionOutput] = ???
+  override def constructUnprovenInput(data: InputBuildRequest): Either[BuilderError, SpentTransactionOutput] = ???
 }

--- a/src/main/scala/co/topl/brambl/builders/MockOutputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockOutputBuilder.scala
@@ -1,15 +1,8 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
-import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.builders.Models.OutputBuildRequest
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
-import co.topl.brambl.models.Datum.{UnspentOutput => Datum}
 
 object MockOutputBuilder extends OutputBuilder {
-  override def constructOutput(
-                                idx: Indices,
-                                datum: Option[Datum],
-                                lock: Lock,
-                                value: Value
-                              ): Either[BuilderError, UnspentTransactionOutput] = ???
+  override def constructOutput(data: OutputBuildRequest): Either[BuilderError, UnspentTransactionOutput] = ???
 }

--- a/src/main/scala/co/topl/brambl/builders/MockOutputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockOutputBuilder.scala
@@ -1,0 +1,15 @@
+package co.topl.brambl.builders
+
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.models.Datum.{UnspentOutput => Datum}
+
+object MockOutputBuilder extends OutputBuilder {
+  override def constructOutput(
+                                idx: Indices,
+                                datum: Option[Datum],
+                                lock: Lock,
+                                value: Value
+                              ): Either[BuilderError, UnspentTransactionOutput] = ???
+}

--- a/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
@@ -1,38 +1,24 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
-import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum, SpentOutput => SpentOutputDatum, UnspentOutput => UnspentOutputDatum}
-import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.builders.Models.{InputBuildRequest, OutputBuildRequest}
+import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum}
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 
 
 object MockTransactionBuilder extends TransactionBuilder {
-  private def collectResult[T](result: List[Either[BuilderError, T]]): (List[BuilderError], List[T]) =
-    result.partitionMap[BuilderError, T](identity)
-
   // Change needs to be explicitly added as an output.
   // Fee is whatever is left over after the sum of the outputs is subtracted from the sum of the inputs.
   override def constructUnprovenTransaction(
-                                    inputIndices: List[Indices],
-                                    inputDatums: List[Option[SpentOutputDatum]],
-                                    outputIndices: List[Indices], // The output indices need to end up as a list of addresses
-                                                                  // Addresses contain the identifier
-                                                                  // The identifier will need to encode evidence of the lock
-                                    outputDatums: List[Option[UnspentOutputDatum]],
-                                    locks: List[Lock],
-                                    outputValues: List[Value],
-                                    datum: Option[IoTransactionDatum]
-                                  ): Either[List[BuilderError], IoTransaction] = {
-    // TODO: Ensure parallel lists are the same length
-    val inputs = collectResult[SpentTransactionOutput] {
-      for (i <- inputIndices.indices.toList)
-        yield MockInputBuilder.constructUnprovenInput(inputIndices(i), inputDatums(i))
-    }
-    val outputs = collectResult[UnspentTransactionOutput] {
-      for (i <- outputIndices.indices.toList)
-        yield MockOutputBuilder.constructOutput(outputIndices(i), outputDatums(i), locks(i), outputValues(i))
-    }
-
+                                             inputRequests: List[InputBuildRequest],
+                                             outputRequests: List[OutputBuildRequest],
+                                             datum: Option[IoTransactionDatum]
+                                           ): Either[List[BuilderError], IoTransaction] = {
+    val inputs = inputRequests
+      .map(MockInputBuilder.constructUnprovenInput)
+      .partitionMap[BuilderError, SpentTransactionOutput](identity)
+    val outputs = outputRequests
+      .map(MockOutputBuilder.constructOutput)
+      .partitionMap[BuilderError, UnspentTransactionOutput](identity)
     if(inputs._1.isEmpty && outputs._1.isEmpty)
       Right(IoTransaction(inputs._2, outputs._2, datum))
     else

--- a/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
@@ -3,10 +3,13 @@ package co.topl.brambl.builders
 import co.topl.brambl.models.Indices
 import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum, SpentOutput => SpentOutputDatum, UnspentOutput => UnspentOutputDatum}
 import co.topl.brambl.models.box.{Lock, Value}
-import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput}
+import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 
 
 object MockTransactionBuilder extends TransactionBuilder {
+  private def collectResult[T](result: List[Either[BuilderError, T]]): (List[BuilderError], List[T]) =
+    result.partitionMap[BuilderError, T](identity)
+
   // Change needs to be explicitly added as an output.
   // Fee is whatever is left over after the sum of the outputs is subtracted from the sum of the inputs.
   override def constructUnprovenTransaction(
@@ -19,13 +22,20 @@ object MockTransactionBuilder extends TransactionBuilder {
                                     locks: List[Lock],
                                     outputValues: List[Value],
                                     datum: Option[IoTransactionDatum]
-                                  ): Either[BuilderError, IoTransaction] = {
+                                  ): Either[List[BuilderError], IoTransaction] = {
     // TODO: Ensure parallel lists are the same length
-    val builtInputs = for (i <- inputIndices.indices.toList)
-      yield MockInputBuilder.constructUnprovenInput(inputIndices(i), inputDatums(i))
-    val x: (List[BuilderError], List[SpentTransactionOutput]) = builtInputs.partitionMap[BuilderError, SpentTransactionOutput]
-    val builtOutputs = for (i <- outputIndices.indices)
-      yield MockOutputBuilder.constructOutput(outputIndices(i), outputDatums(i), locks(i), outputValues(i))
+    val inputs = collectResult[SpentTransactionOutput] {
+      for (i <- inputIndices.indices.toList)
+        yield MockInputBuilder.constructUnprovenInput(inputIndices(i), inputDatums(i))
+    }
+    val outputs = collectResult[UnspentTransactionOutput] {
+      for (i <- outputIndices.indices.toList)
+        yield MockOutputBuilder.constructOutput(outputIndices(i), outputDatums(i), locks(i), outputValues(i))
+    }
 
+    if(inputs._1.isEmpty && outputs._1.isEmpty)
+      Right(IoTransaction(inputs._2, outputs._2, datum))
+    else
+      Left(inputs._1 ++ outputs._1)
   }
 }

--- a/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/MockTransactionBuilder.scala
@@ -1,0 +1,31 @@
+package co.topl.brambl.builders
+
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum, SpentOutput => SpentOutputDatum, UnspentOutput => UnspentOutputDatum}
+import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput}
+
+
+object MockTransactionBuilder extends TransactionBuilder {
+  // Change needs to be explicitly added as an output.
+  // Fee is whatever is left over after the sum of the outputs is subtracted from the sum of the inputs.
+  override def constructUnprovenTransaction(
+                                    inputIndices: List[Indices],
+                                    inputDatums: List[Option[SpentOutputDatum]],
+                                    outputIndices: List[Indices], // The output indices need to end up as a list of addresses
+                                                                  // Addresses contain the identifier
+                                                                  // The identifier will need to encode evidence of the lock
+                                    outputDatums: List[Option[UnspentOutputDatum]],
+                                    locks: List[Lock],
+                                    outputValues: List[Value],
+                                    datum: Option[IoTransactionDatum]
+                                  ): Either[BuilderError, IoTransaction] = {
+    // TODO: Ensure parallel lists are the same length
+    val builtInputs = for (i <- inputIndices.indices.toList)
+      yield MockInputBuilder.constructUnprovenInput(inputIndices(i), inputDatums(i))
+    val x: (List[BuilderError], List[SpentTransactionOutput]) = builtInputs.partitionMap[BuilderError, SpentTransactionOutput]
+    val builtOutputs = for (i <- outputIndices.indices)
+      yield MockOutputBuilder.constructOutput(outputIndices(i), outputDatums(i), locks(i), outputValues(i))
+
+  }
+}

--- a/src/main/scala/co/topl/brambl/builders/Models.scala
+++ b/src/main/scala/co/topl/brambl/builders/Models.scala
@@ -9,17 +9,17 @@ import co.topl.brambl.models.Datum.{
 
 // Temporary until they are added to PB
 object Models {
-  trait OutputBuildRequest {
-    def idx: Indices // The output indices need to end up as a list of addresses
-                     // Addresses contain the identifier
-                     // The identifier will need to encode evidence of the lock
-    def datum: Option[UnspentOutputDatum]
-    def lock: Lock
-    def value: Value
-  }
+  case class OutputBuildRequest(
+    idx: Indices, // The output indices need to end up as a list of addresses
+                  // Addresses contain the identifier
+                  // The identifier will need to encode evidence of the lock
+    datum: Option[UnspentOutputDatum],
+    lock: Lock,
+    value: Value
+  )
 
-  trait InputBuildRequest {
-    def idx: Indices
-    def datum: Option[SpentOutputDatum]
-  }
+  case class InputBuildRequest(
+    idx: Indices,
+    datum: Option[SpentOutputDatum]
+  )
 }

--- a/src/main/scala/co/topl/brambl/builders/Models.scala
+++ b/src/main/scala/co/topl/brambl/builders/Models.scala
@@ -1,0 +1,25 @@
+package co.topl.brambl.builders
+
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.models.Datum.{
+  SpentOutput => SpentOutputDatum,
+  UnspentOutput => UnspentOutputDatum
+}
+
+// Temporary until they are added to PB
+object Models {
+  trait OutputBuildRequest {
+    def idx: Indices // The output indices need to end up as a list of addresses
+                     // Addresses contain the identifier
+                     // The identifier will need to encode evidence of the lock
+    def datum: Option[UnspentOutputDatum]
+    def lock: Lock
+    def value: Value
+  }
+
+  trait InputBuildRequest {
+    def idx: Indices
+    def datum: Option[SpentOutputDatum]
+  }
+}

--- a/src/main/scala/co/topl/brambl/builders/OutputBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/OutputBuilder.scala
@@ -1,15 +1,8 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
+import co.topl.brambl.builders.Models.OutputBuildRequest
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
-import co.topl.brambl.models.Datum.{UnspentOutput => Datum}
-import co.topl.brambl.models.box.{Lock, Value}
 
 trait OutputBuilder {
-  def constructOutput(
-                       idx: Indices,
-                       datum: Option[Datum],
-                       lock: Lock,
-                       value: Value
-                     ): Either[BuilderError, UnspentTransactionOutput]
+  def constructOutput(data: OutputBuildRequest): Either[BuilderError, UnspentTransactionOutput]
 }

--- a/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
@@ -1,9 +1,9 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.{Address, Indices}
+import co.topl.brambl.models.Indices
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum, SpentOutput => SpentOutputDatum, UnspentOutput => UnspentOutputDatum}
-import co.topl.brambl.models.box.Lock
+import co.topl.brambl.models.box.{Lock, Value}
 
 trait TransactionBuilder {
   // Only considering single inputs for now so I don't have to think about box selection algorithm
@@ -24,7 +24,7 @@ trait TransactionBuilder {
                                                           // The identifier will need to encode evidence of the lock
                             outputDatums: List[Option[UnspentOutputDatum]],
                             locks: List[Lock],
-                            quantities: List[Long],
+                            outputValues: List[Value],
                             datum: Option[IoTransactionDatum]
-                           ): Either[BuilderError, IoTransaction]
+                           ): Either[List[BuilderError], IoTransaction]
 }

--- a/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
+++ b/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
@@ -1,30 +1,20 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.Indices
+import co.topl.brambl.builders.Models.{InputBuildRequest, OutputBuildRequest}
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum, SpentOutput => SpentOutputDatum, UnspentOutput => UnspentOutputDatum}
-import co.topl.brambl.models.box.{Lock, Value}
+import co.topl.brambl.models.Datum.{IoTransaction => IoTransactionDatum}
 
 trait TransactionBuilder {
-  // Only considering single inputs for now so I don't have to think about box selection algorithm
   /**
-   * Construct simple transaction
+   * Construct transaction
    *
    * 3:a:A => 1:a:A, 1:a:B, 1:a:C
+   * Currently only thinking through single inputs for now so I don't have to think about box selection algorithm
    *
-   * Like above but considers the locks of the outputs
-   *
-   * TODO: Create some kind of request object to encompass the parallel lists
    */
   def constructUnprovenTransaction(
-                            inputIndices: List[Indices],
-                            inputDatums: List[Option[SpentOutputDatum]],
-                            outputIndices: List[Indices], // The output indices need to end up as a list of addresses
-                                                          // Addresses contain the identifier
-                                                          // The identifier will need to encode evidence of the lock
-                            outputDatums: List[Option[UnspentOutputDatum]],
-                            locks: List[Lock],
-                            outputValues: List[Value],
+                            inputRequests: List[InputBuildRequest],
+                            outputRequests: List[OutputBuildRequest],
                             datum: Option[IoTransactionDatum]
                            ): Either[List[BuilderError], IoTransaction]
 }


### PR DESCRIPTION
Changes:
- Added the Mock implementations of the builder traits from the previous PR. 
- MockTransactionBuilder also has a preliminary implementation
- Replaced the parameters from being parallel lists to a list of XXBuildRequest