### PR TITLE
Updated Protobuf Dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "co.topl" %% "crypto" % "1.10.2",
   "org.typelevel" %% "simulacrum" % "1.0.1",
   "org.scalameta" %% "munit" % "0.7.29" % Test,
-  "com.github.Topl" % "protobuf-specs" % "87dcd9d"
+  "com.github.Topl" % "protobuf-specs" % "21ac57d"
 )
 
 // For Scala 2.13+


### PR DESCRIPTION
Updated protobuf dependency to the latest commit so that users of quivr4s and PB (for ex BramblSc) won't have a conflicting transient dependency

**Testing:**
- Ensured project still builds/compiles as expected.
- Ensured the existing tests all still pass