### PR TITLE
quivr uses bramble crypto dependency, instead of node, DO NOT MERGE

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,13 +5,13 @@ object Dependencies {
   lazy val catsVersion = "2.9.0"
 
   val sourcesDependencies = Seq(
-    "org.typelevel"        %% "cats-core"   % catsVersion,
-    "org.typelevel"        %% "cats-free"   % catsVersion,
-    "org.typelevel"        %% "cats-effect" % "3.4.1",
-    "org.scorexfoundation" %% "scrypto"     % "2.2.1",
-    "co.topl"              %% "crypto"      % "1.10.2",
-    "org.typelevel"        %% "simulacrum"  % "1.0.1",
-    "com.github.Topl" % "protobuf-specs" % "c920f90" // scala-steward:off
+    "org.typelevel"        %% "cats-core"      % catsVersion,
+    "org.typelevel"        %% "cats-free"      % catsVersion,
+    "org.typelevel"        %% "cats-effect"    % "3.4.1",
+    "org.scorexfoundation" %% "scrypto"        % "2.2.1",
+    "org.typelevel"        %% "simulacrum"     % "1.0.1",
+    "com.github.Topl"       % "BramblSc"       % "652cdaa", // scala-steward:off
+    "com.github.Topl"       % "protobuf-specs" % "c920f90" // scala-steward:off
   )
 
   val testsDependencies = Seq(


### PR DESCRIPTION
## Purpose
quivr uses bramble crypto dependency, instead of node

## Approach
use Brambl latest commit

## Testing
prepare PR ok
## Tickets
