### PR TITLE
Quivr Verifier API: Added default case

### DIFF
--- a/src/main/scala/co/topl/quivr/api/Verifier.scala
+++ b/src/main/scala/co/topl/quivr/api/Verifier.scala
@@ -359,6 +359,8 @@ object Verifier {
               andVerifier(c, r, context)
             case (Proposition.Value.Or(c), Proof.Value.Or(r)) =>
               orVerifier(c, r, context)
+            // Proposition and Proof are not of the same type or either are Empty => Authorization fails
+            case _ => Either.left[QuivrRuntimeError, Boolean](EvaluationAuthorizationFailed(proposition, proof)).pure[F]
           }
       }
   }

--- a/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
+++ b/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
@@ -187,12 +187,11 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
       proof,
       dynamicContext(proposition, proof)
     )
-    assertEquals(result.isLeft, true)
-    assertEquals(
+    assert(result.isLeft)
+    assert(
       result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
         true
-      }.isDefined,
-      true
+      }.isDefined
     )
   }
 
@@ -204,12 +203,11 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
       proof,
       dynamicContext(proposition, proof)
     )
-    assertEquals(result.isLeft, true)
-    assertEquals(
+    assert(result.isLeft)
+    assert(
       result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
         true
-      }.isDefined,
-      true
+      }.isDefined
     )
   }
 
@@ -221,12 +219,11 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
       proof,
       dynamicContext(proposition, proof)
     )
-    assertEquals(result.isLeft, true)
-    assertEquals(
+    assert(result.isLeft)
+    assert(
       result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
         true
-      }.isDefined,
-      true
+      }.isDefined
     )
   }
 }

--- a/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
+++ b/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
@@ -179,4 +179,54 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
     )
   }
 
+  test("Proposition and Proof with mismatched types fails validation") {
+    val proposition = heightProposer.propose("height", 900, 1000)
+    val proof = tickProver.prove((), signableBytes)
+    val result = verifierInstance[Id, Datum].evaluate(
+      proposition,
+      proof,
+      dynamicContext(proposition, proof)
+    )
+    assertEquals(result.isLeft, true)
+    assertEquals(
+      result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
+        true
+      }.isDefined,
+      true
+    )
+  }
+
+  test("Empty Proof fails validation") {
+    val proposition = heightProposer.propose("height", 900, 1000)
+    val proof = Proof()
+    val result = verifierInstance[Id, Datum].evaluate(
+      proposition,
+      proof,
+      dynamicContext(proposition, proof)
+    )
+    assertEquals(result.isLeft, true)
+    assertEquals(
+      result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
+        true
+      }.isDefined,
+      true
+    )
+  }
+
+  test("Empty Proposition fails validation") {
+    val proposition = Proposition()
+    val proof = tickProver.prove((), signableBytes)
+    val result = verifierInstance[Id, Datum].evaluate(
+      proposition,
+      proof,
+      dynamicContext(proposition, proof)
+    )
+    assertEquals(result.isLeft, true)
+    assertEquals(
+      result.left.toOption.collect { case QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed(_, _) =>
+        true
+      }.isDefined,
+      true
+    )
+  }
 }


### PR DESCRIPTION
## Purpose

This is needed for Proposition.Value.Empty, Proof.Value.Empty, and mismatched types.

## Approach

Added default case during verification; will result in an EvaluationAuthorization error

## Testing

- Added basic unit tests
- Ensured all existing tests still pass

## Tickets
* No direct ticket but it relates to TSDK-304