### PR TITLE
Use bouncycastle

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     "org.typelevel"        %% "cats-free"      % catsVersion,
     "org.typelevel"        %% "cats-effect"    % "3.4.8",
     "org.scorexfoundation" %% "scrypto"        % "2.2.1",
-    "co.topl"              %% "crypto"         % "1.10.2",
+    "org.bouncycastle"      % "bcprov-jdk18on" % "1.72",
     "org.typelevel"        %% "simulacrum"     % "1.0.1",
     "com.github.Topl"       % "protobuf-specs" % "7d2ba5c" // scala-steward:off
   )

--- a/src/main/scala/co/topl/quivr/api/Prover.scala
+++ b/src/main/scala/co/topl/quivr/api/Prover.scala
@@ -2,7 +2,6 @@ package co.topl.quivr.api
 
 import cats.Applicative
 import cats.implicits._
-import co.topl.crypto.hash.blake2b256
 import co.topl.quivr.Tokens
 import com.google.protobuf.ByteString
 import quivr.models._
@@ -34,7 +33,10 @@ object Prover {
   private def blake2b256Bind(tag: String, message: SignableBytes): TxBind =
     TxBind(
       ByteString.copyFrom(
-        blake2b256.hash(tag.getBytes(StandardCharsets.UTF_8) ++ message.value.toByteArray).value
+        blake2b256Hash(
+          tag.getBytes(StandardCharsets.UTF_8) ++
+          message.value.toByteArray
+        )
       )
     )
 

--- a/src/main/scala/co/topl/quivr/api/Verifier.scala
+++ b/src/main/scala/co/topl/quivr/api/Verifier.scala
@@ -3,7 +3,6 @@ package co.topl.quivr.api
 import cats._
 import cats.data.OptionT
 import cats.implicits._
-import co.topl.crypto.hash.blake2b256
 import co.topl.quivr._
 import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
   EvaluationAuthorizationFailed,
@@ -43,8 +42,8 @@ object Verifier {
     proofTxBind: TxBind,
     context:     DynamicContext[F, A, _]
   ): F[Either[QuivrRuntimeError, Boolean]] = for {
-    sb             <- context.signableBytes
-    verifierTxBind <- blake2b256.hash(tag.getBytes(StandardCharsets.UTF_8) ++ sb.value.toByteArray).value.pure[F]
+    sb <- context.signableBytes
+    verifierTxBind = blake2b256Hash(tag.getBytes(StandardCharsets.UTF_8) ++ sb.value.toByteArray)
     res = Either.cond(
       verifierTxBind sameElements proofTxBind.value.toByteArray,
       true,

--- a/src/main/scala/co/topl/quivr/api/package.scala
+++ b/src/main/scala/co/topl/quivr/api/package.scala
@@ -1,0 +1,19 @@
+package co.topl.quivr
+
+import org.bouncycastle.crypto.digests.Blake2bDigest
+
+package object api {
+
+  /**
+   * Compute the Blake2b-256 hash of the input
+   * @param in array of any length
+   * @return array of length=32
+   */
+  def blake2b256Hash(in: Array[Byte]): Array[Byte] = {
+    val blake2b256 = new Blake2bDigest(256)
+    blake2b256.update(in, 0, in.length)
+    val out = new Array[Byte](32)
+    blake2b256.doFinal(out, 0)
+    out
+  }
+}

--- a/src/test/scala/co/topl/quivr/QuivrCompositeOpsTests.scala
+++ b/src/test/scala/co/topl/quivr/QuivrCompositeOpsTests.scala
@@ -3,7 +3,6 @@ package co.topl.quivr
 import cats.Id
 import cats.Monad
 import quivr.models._
-import co.topl.crypto.signatures.Curve25519
 import co.topl.quivr.runtime.QuivrRuntimeErrors
 import com.google.protobuf.ByteString
 
@@ -21,17 +20,15 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
   implicit val applicativeId: Monad[Id] = cats.catsInstancesForId
 
   test("An and proposition must evaluate to true when both the verification of both proofs is true") {
-    val (sk1, vk1) = Curve25519.createKeyPair
-    val (sk2, vk2) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
+    val (sk1, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
     val andProposition = andProposer.propose(signatureProposition1, signatureProposition2)
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val andProverProof = andProver.prove((signatureProverProof1, signatureProverProof2), signableBytes)
     val result =
       verifierInstance.evaluate(andProposition, andProverProof, dynamicContext(andProposition, andProverProof))
@@ -39,18 +36,16 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
   }
 
   test("An and proposition must evaluate to false when one of the proofs evaluates to false") {
-    val (sk1, vk1) = Curve25519.createKeyPair
-    val (_, vk2) = Curve25519.createKeyPair
-    val (sk2, _) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
+    val (sk1, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
     val andProposition = andProposer.propose(signatureProposition1, signatureProposition2)
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val andProverProof = andProver.prove((signatureProverProof1, signatureProverProof2), signableBytes)
     val result =
       verifierInstance.evaluate(andProposition, andProverProof, dynamicContext(andProposition, andProverProof))
@@ -64,37 +59,33 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
   }
 
   test("An or proposition must evaluate to true when one of the proofs evaluates to true") {
-    val (sk1, vk1) = Curve25519.createKeyPair
-    val (_, vk2) = Curve25519.createKeyPair
-    val (sk2, _) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
+    val (sk1, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
     val orProposition = orProposer.propose(signatureProposition1, signatureProposition2)
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val orProverProof = orProver.prove((signatureProverProof1, signatureProverProof2), signableBytes)
     val result = verifierInstance.evaluate(orProposition, orProverProof, dynamicContext(orProposition, orProverProof))
     assertEquals(result.isRight, true)
   }
 
   test("An or proposition must evaluate to false when both proofs evaluate to false") {
-    val (_, vk1) = Curve25519.createKeyPair
-    val (sk1, _) = Curve25519.createKeyPair
-    val (_, vk2) = Curve25519.createKeyPair
-    val (sk2, _) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
+    val (_, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk1, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
     val orProposition = orProposer.propose(signatureProposition1, signatureProposition2)
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val orProverProof = orProver.prove((signatureProverProof1, signatureProverProof2), signableBytes)
     val result = verifierInstance.evaluate(orProposition, orProverProof, dynamicContext(orProposition, orProverProof))
     assertEquals(result.isLeft, true)
@@ -133,24 +124,21 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
   }
 
   test("A threshold proposition must evaluate to true when the threshold is passed") {
-    val (sk1, vk1) = Curve25519.createKeyPair
-    val (_, vk2) = Curve25519.createKeyPair
-    val (sk2, _) = Curve25519.createKeyPair
-    val (sk3, vk3) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val vk3Bytes = vk3.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
-    val signatureProposition3 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk3Bytes)))
+    val (sk1, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk3, vk3) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
+    val signatureProposition3 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk3)))
     val thresholdProposition =
       thresholdProposer.propose((Set(signatureProposition1, signatureProposition2, signatureProposition3), 2))
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signature3 = Curve25519.sign(sk3, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
-    val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signature3 = VerySecureSignatureRoutine.sign(sk3, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
+    val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3)), signableBytes)
     val thresholdProverProof = thresholdProver.prove(
       Set(Some(signatureProverProof1), Some(signatureProverProof2), Some(signatureProverProof3)),
       signableBytes
@@ -164,22 +152,17 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
   }
 
   test("A threshold proposition must evaluate to false when the threshold is not passed") {
-    val (sk1, vk1) = Curve25519.createKeyPair
-    val (_, vk2) = Curve25519.createKeyPair
-    val (sk2, _) = Curve25519.createKeyPair
-    val (sk3, vk3) = Curve25519.createKeyPair
-    val (_, vk4) = Curve25519.createKeyPair
-    val (_, vk5) = Curve25519.createKeyPair
-    val vk1Bytes = vk1.value
-    val vk2Bytes = vk2.value
-    val vk3Bytes = vk3.value
-    val vk4Bytes = vk4.value
-    val vk5Bytes = vk5.value
-    val signatureProposition1 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk1Bytes)))
-    val signatureProposition2 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk2Bytes)))
-    val signatureProposition3 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk3Bytes)))
-    val signatureProposition4 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk4Bytes)))
-    val signatureProposition5 = signatureProposer.propose("Curve25519", VerificationKey(ByteString.copyFrom(vk5Bytes)))
+    val (sk1, vk1) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk2) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk2, _) = VerySecureSignatureRoutine.generateKeyPair()
+    val (sk3, vk3) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk4) = VerySecureSignatureRoutine.generateKeyPair()
+    val (_, vk5) = VerySecureSignatureRoutine.generateKeyPair()
+    val signatureProposition1 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk1)))
+    val signatureProposition2 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk2)))
+    val signatureProposition3 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk3)))
+    val signatureProposition4 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk4)))
+    val signatureProposition5 = signatureProposer.propose("VerySecure", VerificationKey(ByteString.copyFrom(vk5)))
     val thresholdProposition = thresholdProposer.propose(
       (
         Set(
@@ -192,12 +175,12 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
         3
       )
     )
-    val signature1 = Curve25519.sign(sk1, signableBytes.value.toByteArray)
-    val signature2 = Curve25519.sign(sk2, signableBytes.value.toByteArray)
-    val signature3 = Curve25519.sign(sk3, signableBytes.value.toByteArray)
-    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1.value)), signableBytes)
-    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2.value)), signableBytes)
-    val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3.value)), signableBytes)
+    val signature1 = VerySecureSignatureRoutine.sign(sk1, signableBytes.value.toByteArray)
+    val signature2 = VerySecureSignatureRoutine.sign(sk2, signableBytes.value.toByteArray)
+    val signature3 = VerySecureSignatureRoutine.sign(sk3, signableBytes.value.toByteArray)
+    val signatureProverProof1 = signatureProver.prove(Witness(ByteString.copyFrom(signature1)), signableBytes)
+    val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
+    val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3)), signableBytes)
     val thresholdProverProof = thresholdProver.prove(
       Set(Some(signatureProverProof1), Some(signatureProverProof2), Some(signatureProverProof3)),
       signableBytes

--- a/src/test/scala/co/topl/quivr/VerySecureSignatureRoutine.scala
+++ b/src/test/scala/co/topl/quivr/VerySecureSignatureRoutine.scala
@@ -1,0 +1,51 @@
+package co.topl.quivr
+
+import org.bouncycastle.crypto.digests.Blake2bDigest
+
+import scala.util.Random
+
+/**
+ * A top-secret signature scheme that is very secure.  Yes, this is just a joke.  The point is that
+ * the signing routine is plug-and-play, and can be replaced with any other signature scheme depending on context.
+ */
+object VerySecureSignatureRoutine {
+
+  /**
+   * Produces a key pair.  The secret key is 32 bytes, and the verification key is the reverse of the secret key.
+   * @return a (SK, VK) tuple
+   */
+  def generateKeyPair(): (Array[Byte], Array[Byte]) = {
+    val sk = Random.nextBytes(32)
+    val vk = sk.reverse
+    (sk, vk)
+  }
+
+  /**
+   * Signs the given msg with the given sk.  The signature is the Blake2b-512 hash of the concatenation of the sk and msg.
+   * @param sk a 32-byte SK
+   * @param msg any length message
+   * @return a 64-byte signature
+   */
+  def sign(sk: Array[Byte], msg: Array[Byte]): Array[Byte] = {
+    val in = sk ++ msg
+    val blake2b512 = new Blake2bDigest(512)
+    blake2b512.update(in, 0, in.length)
+    val out = new Array[Byte](64)
+    blake2b512.doFinal(out, 0)
+    out
+  }
+
+  /**
+   * Verifies the given signature against the given msg and vk.  The signature is valid if it is equal to the Blake2b-512
+   * hash of the concatenation of the reversed-vk and msg.
+   * @param sig a 64-byte signature
+   * @param msg a message of any length
+   * @param vk a 32-byte VK
+   * @return true if valid, false if invalid
+   */
+  def verify(sig: Array[Byte], msg: Array[Byte], vk: Array[Byte]): Boolean = {
+    val expectedSig = sign(vk.reverse, msg)
+    sig sameElements expectedSig
+  }
+
+}


### PR DESCRIPTION
## Purpose
- The crypto functionality currently uses the Dion crypto library which is binary incompatible with the Tetra crypto library
- We only need crypto routines for blake2b256 in the main code, and Curve25519 in the test code
## Approach
- Replace usage of Dion crypto's blake2b256 with bouncycastle's blake2b directly
- Replace usage of Curve25519 with a fake "VerySecureSignatureRoutine" implementation
## Testing
- `preparePR` locally
## Tickets
- TSDK-243