### PR TITLE
Update protobuf-specs, Digest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,12 +5,12 @@ object Dependencies {
   lazy val catsVersion = "2.9.0"
 
   val sourcesDependencies = Seq(
-    "org.typelevel"   %% "cats-core"      % catsVersion,
-    "org.typelevel"   %% "cats-free"      % catsVersion,
-    "org.typelevel"   %% "cats-effect"    % "3.4.8",
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.72",
-    "org.typelevel"   %% "simulacrum"     % "1.0.1",
-    "com.github.Topl"  % "protobuf-specs" % "b745cb1" // scala-steward:off
+    "org.typelevel"                  %% "cats-core"      % catsVersion,
+    "org.typelevel"                  %% "cats-free"      % catsVersion,
+    "org.typelevel"                  %% "cats-effect"    % "3.4.8",
+    "org.bouncycastle"                % "bcprov-jdk18on" % "1.72",
+    "org.typelevel"                  %% "simulacrum"     % "1.0.1",
+    "com.github.Topl.protobuf-specs" %% "protobuf-fs2"   % "110e109" // scala-steward:off
   )
 
   val testsDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     "org.typelevel"                  %% "cats-effect"    % "3.4.8",
     "org.bouncycastle"                % "bcprov-jdk18on" % "1.72",
     "org.typelevel"                  %% "simulacrum"     % "1.0.1",
-    "com.github.Topl.protobuf-specs" %% "protobuf-fs2"   % "110e109" // scala-steward:off
+    "com.github.Topl.protobuf-specs" %% "protobuf-fs2"   % "ba616f0" // scala-steward:off
   )
 
   val testsDependencies = Seq(

--- a/src/test/scala/co/topl/quivr/MockHelpers.scala
+++ b/src/test/scala/co/topl/quivr/MockHelpers.scala
@@ -52,7 +52,7 @@ trait MockHelpers {
 
         override def validate(v: DigestVerification): Either[QuivrRuntimeError, DigestVerification] = {
           val test = co.topl.quivr.api.blake2b256Hash(v.preimage.input.toByteArray ++ v.preimage.salt.toByteArray)
-          if (v.digest.value.digest32.get.value.toByteArray.sameElements(test)) Right(v)
+          if (v.digest.value.toByteArray.sameElements(test)) Right(v)
           else Left(QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable)
         }
       })

--- a/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
+++ b/src/test/scala/co/topl/quivr/QuivrAtomicOpTests.scala
@@ -5,8 +5,8 @@ import cats.Monad
 import co.topl.brambl.models.Datum
 import co.topl.quivr.runtime.QuivrRuntimeErrors
 import com.google.protobuf.ByteString
-import quivr.models._
 import quivr.models.VerificationKey._
+import quivr.models._
 
 /**
  * Set of tests for the Quivr Atomic Operations.
@@ -14,9 +14,7 @@ import quivr.models.VerificationKey._
 class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
 
   import co.topl.quivr.api.Proposer._
-
   import co.topl.quivr.api.Prover._
-
   import co.topl.quivr.api.Verifier.instances._
 
   implicit val applicativeId: Monad[Id] = cats.catsInstancesForId
@@ -140,11 +138,9 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
   test("A digest proposition must evaluate to true when the digest is correct") {
     val mySalt = ByteString.copyFromUtf8("I am a digest")
     val myPreimage = Preimage(ByteString.copyFromUtf8("I am a preimage"), mySalt)
-    val myDigest = Digest().withDigest32(
-      Digest.Digest32(
-        ByteString.copyFrom(
-          co.topl.quivr.api.blake2b256Hash(myPreimage.input.toByteArray ++ myPreimage.salt.toByteArray)
-        )
+    val myDigest = Digest(
+      ByteString.copyFrom(
+        co.topl.quivr.api.blake2b256Hash(myPreimage.input.toByteArray ++ myPreimage.salt.toByteArray)
       )
     )
     val digestProposition = digestProposer.propose(("blake2b256", myDigest))
@@ -160,11 +156,9 @@ class QuivrAtomicOpTests extends munit.FunSuite with MockHelpers {
   test("A digest proposition must evaluate to false when the digest is incorrect") {
     val mySalt = ByteString.copyFromUtf8("I am a digest")
     val myPreimage = Preimage(ByteString.copyFromUtf8("I am a preimage"), mySalt)
-    val myDigest = Digest().withDigest32(
-      Digest.Digest32(
-        ByteString.copyFrom(
-          co.topl.quivr.api.blake2b256Hash(myPreimage.input.toByteArray ++ myPreimage.salt.toByteArray)
-        )
+    val myDigest = Digest(
+      ByteString.copyFrom(
+        co.topl.quivr.api.blake2b256Hash(myPreimage.input.toByteArray ++ myPreimage.salt.toByteArray)
       )
     )
     val wrongPreImage = Preimage(ByteString.copyFromUtf8("I am a wrong preimage"), mySalt)

--- a/src/test/scala/co/topl/quivr/generators/ModelGenerators.scala
+++ b/src/test/scala/co/topl/quivr/generators/ModelGenerators.scala
@@ -2,7 +2,7 @@ package co.topl.quivr.generators
 
 import com.google.protobuf.ByteString
 import org.scalacheck.{Arbitrary, Gen}
-import quivr.models.Digest.{Digest32, Digest64}
+import quivr.models.Digest
 
 trait ModelGenerators {
 
@@ -13,18 +13,11 @@ trait ModelGenerators {
       .containerOfN[Array, Byte](n, byteGen)
       .map(ByteString.copyFrom)
 
-  val arbitraryDigest32: Arbitrary[Digest32] =
+  val arbitraryDigest: Arbitrary[Digest] =
     Arbitrary(
       for {
         bs <- genSizedStrictByteString(32)()
-      } yield Digest32(bs)
-    )
-
-  val arbitraryDigest64: Arbitrary[Digest64] =
-    Arbitrary(
-      for {
-        bs <- genSizedStrictByteString(64)()
-      } yield Digest64(bs)
+      } yield Digest(bs)
     )
 
 }


### PR DESCRIPTION
## Purpose
- protobuf-specs has been [updated](https://github.com/Topl/protobuf-specs/pull/54) to remove separate 32/64 length types, in particular the Digest32/64 types
## Approach
- Combine definition into single Digest type
## Testing
- Implemented in BramblSc and Bifrfost
## Tickets
- #BN-963