### PR TITLE
TSDK-462: Minor Improvement to Threshold Prover

### DIFF
--- a/src/main/scala/co/topl/quivr/api/Prover.scala
+++ b/src/main/scala/co/topl/quivr/api/Prover.scala
@@ -93,14 +93,13 @@ object Prover {
         .withEqualTo(Proof.EqualTo(blake2b256Bind(Tokens.EqualTo, message)))
         .pure[F]
 
-  // TODO: Protobuf's `Proof` type already encapsulates "emptiness", so the Option may be unnecessary here
-  def thresholdProver[F[_]: Applicative]: Prover[F, Set[Option[Proof]]] =
-    (challenges: Set[Option[Proof]], message: SignableBytes) =>
+  def thresholdProver[F[_]: Applicative]: Prover[F, Set[Proof]] =
+    (challenges: Set[Proof], message: SignableBytes) =>
       Proof()
         .withThreshold(
           Proof.Threshold(
             blake2b256Bind(Tokens.Threshold, message),
-            challenges.toSeq.map(_.getOrElse(Proof()))
+            challenges.toSeq
           )
         )
         .pure[F]

--- a/src/main/scala/co/topl/quivr/api/Verifier.scala
+++ b/src/main/scala/co/topl/quivr/api/Verifier.scala
@@ -240,7 +240,7 @@ object Verifier {
         msgResult <- Verifier.evaluateBlake2b256Bind(Tokens.Threshold, wrappedProof, proof.transactionBind, context)
         evalResult <-
           if (proposition.threshold === 0) Right(true).pure[F]
-          else if (proposition.threshold >= proposition.challenges.size)
+          else if (proposition.threshold > proposition.challenges.size)
             Left(EvaluationAuthorizationFailed(wrappedProposition, wrappedProof)).pure[F]
           else if (proof.responses.isEmpty)
             Left(EvaluationAuthorizationFailed(wrappedProposition, wrappedProof)).pure[F]

--- a/src/test/scala/co/topl/quivr/QuivrCompositeOpsTests.scala
+++ b/src/test/scala/co/topl/quivr/QuivrCompositeOpsTests.scala
@@ -174,7 +174,7 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
     val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3)), signableBytes)
     val thresholdProverProof = thresholdProver.prove(
-      Set(Some(signatureProverProof1), Some(signatureProverProof2), Some(signatureProverProof3)),
+      Set(signatureProverProof1, signatureProverProof2, signatureProverProof3),
       signableBytes
     )
     val result = verifierInstance.evaluate(
@@ -231,7 +231,7 @@ class QuivrCompositeOpsTests extends munit.FunSuite with MockHelpers {
     val signatureProverProof2 = signatureProver.prove(Witness(ByteString.copyFrom(signature2)), signableBytes)
     val signatureProverProof3 = signatureProver.prove(Witness(ByteString.copyFrom(signature3)), signableBytes)
     val thresholdProverProof = thresholdProver.prove(
-      Set(Some(signatureProverProof1), Some(signatureProverProof2), Some(signatureProverProof3)),
+      Set(signatureProverProof1, signatureProverProof2, signatureProverProof3),
       signableBytes
     )
     val result = verifierInstance.evaluate(


### PR DESCRIPTION
## Purpose

Threshold Prover took in a Set of Optional Proofs. This adds unnecessary complexity as an Empty Proof is denoted by Proof() (empty value from PB).

## Approach

- Updated Threshold Prover to take in a Set of Proofs instead of a Set of Optional Proofs.
- Fixed minor bug in Threshold Verifier: Previously it erroneously failed if # of challenges = threshold. The threshold can be met if all of those challenges are valid. 

## Testing

- updated affected tests
- Ran `checkPR` and ensure successful
- Used it in BramblSc

## Tickets
* Part of TSDK-462