### PR TITLE
Initial changes for deploy tooling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Pull Requests
+
+  $CHANGES

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,12 +1,9 @@
 name: Maven Central Release
-#on:
-#  push:
-#    branches: [main]
-#    tags: ["*"]
 
 on:
   push:
-    branches: [ TSDK-495 ]
+    branches: [main]
+    tags: ["*"]
 
 jobs:
   maven_release:

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,0 +1,31 @@
+name: Maven Central Release
+#on:
+#  push:
+#    branches: [main]
+#    tags: ["*"]
+
+on:
+  push:
+    branches: [ TSDK-495 ]
+
+jobs:
+  maven_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - uses: olafurpg/setup-scala@v14
+      - uses: olafurpg/setup-gpg@v3
+
+      - name: Publish artifacts to Maven Central
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          CI_SONATYPE_RELEASE: ${{ secrets.CI_SONATYPE_RELEASE }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 inThisBuild(
   List(
     organization := "co.topl",
-    version := "0.1",
     licenses := Seq("MPL2.0" -> url("https://www.mozilla.org/en-US/MPL/2.0/")),
     scalaVersion := "2.13.10"
   )
@@ -18,12 +17,15 @@ lazy val commonSettings = Seq(
   semanticdbVersion := scalafixSemanticdb.revision,
   resolvers ++= Seq(
     "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/",
+    "Sonatype Releases s01" at "https://s01.oss.sonatype.org/content/repositories/releases/",
     "jitpack" at "https://jitpack.io"
   )
 )
 
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/Topl/quivr4s")),
+  ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
+  sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   Test / publishArtifact := true,
   pomIncludeRepository := { _ => false },
   pomExtra :=

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     "org.typelevel"                  %% "cats-effect"    % "3.4.8",
     "org.bouncycastle"                % "bcprov-jdk18on" % "1.72",
     "org.typelevel"                  %% "simulacrum"     % "1.0.1",
-    "com.github.Topl.protobuf-specs" %% "protobuf-fs2"   % "8bb8a3b" // scala-steward:off
+    "co.topl" %% "protobuf-fs2" % "2.0.0-alpha1",
   )
 
   val testsDependencies = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")


### PR DESCRIPTION
## Purpose

Tooling for publishing quivr4s to Maven

## Approach

- Added Release drafter workflow
- Added publish workflow (added the necessary secrets to the repo)
- note: version is removed from build.sbt since sbt-ci-release says not to set version as it is handled by sbt-dynver

## Testing

* Ensured publish workflow is successful > Github Actions ran successfully and artifact snapshot exists in sonatype repo
* Ensured artifact snapshot is accessible from coursier > Ran `cs fetch co.topl:quivr4s_2.13:0.0.0+206-1b18bcac-SNAPSHOT -r https://s01.oss.sonatype.org/content/repositories/snapshots` > fetch from sonatype repo was successful
* Ensured `sbt publishLocal` still works (sanity)

Could not yet test (will do after PR is merged):

* Release drafter workflow (file needs to be on the main branch)
* Proper version or access from maven central since there have been no releases

## Tickets
* Closes TSDK-495