### PR TITLE
TSDK-495 Maven Release Fix

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -25,4 +25,3 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          CI_SONATYPE_RELEASE: ${{ secrets.CI_SONATYPE_RELEASE }}


### PR DESCRIPTION
## Purpose

Yesterday the publish workflow was added and a git tag was pushed. This successfully ran [the workflow with no errors](https://github.com/Topl/quivr4s/actions/runs/5405973557/jobs/9822253606). However, after waiting many hours/overnight, the artifact still does not appear on maven: https://central.sonatype.com/namespace/co.topl and https://repo1.maven.org/maven2/co/topl/ . 

Upon further inspection of the logs (and comparing to the logs from protobuf specs) it looks like the actions runner published the quivr4s package locally but not remotely to sonatype.

![image](https://github.com/Topl/quivr4s/assets/17934976/69823f3a-95af-439c-aab1-a314b434bcd7)
![image](https://github.com/Topl/quivr4s/assets/17934976/39e05f1b-5bb0-4db5-84ef-ba27576e9b79)
 

It looks like the cause is specifying `CI_SONATYPE_RELEASE` in maven_release.yml. This was not specified in protobuf specs but was erroneously added to quivr4s (since this file was copy-pasted from BramblSc).

From the [documentation](https://github.com/sbt/sbt-ci-release#secrets), 
![image](https://github.com/Topl/quivr4s/assets/17934976/0ef8377b-7201-458c-86eb-e5e5194c6777) 
Since we did not have a value in the secrets for this line but we still provided the value, we did not have a command to run to release to Sonatype (since the default would not have been used). 


## Approach

Minor change to maven release workflow to remove CI_SONATYPE_RELEASE. 

## Testing

- Ran `sbt publishLocal` as a sanity
- The real test to see if this works would come after merging and pushing a new tag

## Tickets
* TSDK-495
