### PR TITLE
TSDK-470 Mark protobuf-fs2 as provided

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     "org.typelevel"   %% "cats-effect"    % "3.4.8",
     "org.bouncycastle" % "bcprov-jdk18on" % "1.72",
     "org.typelevel"   %% "simulacrum"     % "1.0.1",
-    "co.topl"         %% "protobuf-fs2"   % "2.0.0-alpha1"
+    "co.topl"         %% "protobuf-fs2"   % "2.0.0-alpha1" % "provided"
   )
 
   val testsDependencies = Seq(


### PR DESCRIPTION
## Purpose

The goal of this PR is to mark the protobuf-fs2 as provided. The goal is to force other projects that use quivr4s to provide the dependency by themselves so that no version conflicts appear.

## Approach

We mark the dependency as provided in the `build.sbt` file.

## Testing

No testing necessary. Testing will happen in downstream projects.

## Tickets
* TSDK-470 is the task where this problem was discovered
