### PR TITLE
TSDK-507 Release drafts should not contain changes from previous pre-release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+prerelease: true
 include-pre-releases: true
 template: |
   ## Pull Requests

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+include-pre-releases: true
 template: |
   ## Pull Requests
 


### PR DESCRIPTION
## Purpose

The release draft that will be used for alpha2 also contains all PRs that was in alpha1:
https://github.com/Topl/quivr4s/releases/tag/untagged-0e5253d4a1b468415f79

## Approach

- Added configuration flag to consider pre-releases as a "full" release when drafting notes
- Also added configuration flag to mark as pre-release by default to streamline process 

## Testing

- Tested in my own personal repo that this change fixes the issue
- The test for this repo will be apparent after we merge

## Tickets
* TSDK-507